### PR TITLE
Windows compatibility

### DIFF
--- a/Compat.h
+++ b/Compat.h
@@ -1,0 +1,11 @@
+/**************************************/
+#pragma once
+/**************************************/
+#ifdef _WIN32
+	#include <malloc.h>
+	#define aligned_alloc(alignment,size) _aligned_malloc (size, alignment)
+	#define free_aligned(x) _aligned_free (x)
+#else
+	#define free_aligned(x) free (x)
+#endif
+/**************************************/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	mkdir -p release
-	$(CC) -O2 -Wall -Wextra Bitmap.c Quantize.c Tiles.c tilequant.c -o release/tilequant
+	$(CC) -lm -O2 -Wall -Wextra Bitmap.c Quantize.c Tiles.c tilequant.c -o release/tilequant
 
 .PHONY: clean
 clean:

--- a/Tiles.c
+++ b/Tiles.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 /**************************************/
+#include "Compat.h"
 #include "Quantize.h"
 #include "Tiles.h"
 /**************************************/
@@ -188,7 +189,7 @@ int TilesData_QuantizePalettes(struct TilesData_t *TilesData, struct YUVAf_t *Pa
 	}
 
 	//! Clean up, return
-	free(Clusters);
+	free_aligned(Clusters);
 	return 1;
 }
 

--- a/tilequant.c
+++ b/tilequant.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 /**************************************/
+#include "Compat.h"
 #include "Bitmap.h"
 #include "PxType.h"
 #include "Tiles.h"
@@ -192,12 +193,12 @@ int main(int argc, const char *argv[]) {
 		printf("Out of memory; image not processed\n");
 		free(Palette);
 		free(PxData);
-		free(TilesData);
+		free_aligned(TilesData);
 		BmpCtx_Destroy(&Image);
 		return -1;
 	}
 	struct YUVAf_t RMSE = ProcessImage(&Image, TilesData, PxData, Palette, MaxTilePals, MaxPalSize);
-	free(TilesData);
+	free_aligned(TilesData);
 
 	//! Output PSNR
 #if MEASURE_PSNR


### PR DESCRIPTION
`aligned_alloc` is not available on Windows, but `_aligned_malloc` is as a replacement. This PR defines `aligned_alloc` via `_aligned_malloc` for Windows, making Tilequant compile on Windows.

I tested this with Msys.

I also had to modify the Makefile to link it with the math library to get it to compile on both my Windows and my Arch Linux machines.

I'm not really a C developer, so sorry if the way I did it isn't ideal, I'm happy to change stuff!
